### PR TITLE
Only add_subdirectory(tests) if PROJECT_IS_TOP_LEVEL is TRUE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(ResolveRoboticsURICpp
         LANGUAGES CXX C
-        VERSION 0.0.1)
+        VERSION 0.0.2)
 
 include(GNUInstallDirs)
 
@@ -92,7 +92,7 @@ if(RRUC_INSTALL)
     include(AddUninstallTarget)
 endif()
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND PROJECT_IS_TOP_LEVEL)
     add_subdirectory(test)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT DEFINED PROJECT_IS_TOP_LEVEL)
     endif()
 endif()
 
-option(BUILD_TESTING "Create tests using CMake" ${PROJECT_IS_TOP_LEVEL})
+option(BUILD_TESTING "Create tests using CMake" OFF)
 
 if(BUILD_TESTING)
     enable_testing()


### PR DESCRIPTION
Add bump version to 0.0.2.

The problem in this context is that if a project includes `resolve-robotics-uri-cpp` via FetchContent, if the project already has set `BUILD_TESTING` to `ON`, the tests of  `resolve-robotics-uri-cpp` are added, and this can result in a failure if `Catch2` is not installed.

To avoid further problems, I also set `BUILD_TESTING` to `OFF` by default, and I enabled it explicitly in the pixi build.

Problem found by @loremoretti .