### PR TITLE
Add support to find models in active virtual environment without setting any additional env variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,17 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-22.04, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Print used environment (no conda) [Conda]
       shell: bash
       run: |
         env
 
-    - uses: prefix-dev/setup-pixi@v0.8.3
+    - uses: prefix-dev/setup-pixi@v0.9.6
 
     - name: Install the package
       shell: bash -l {0}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(ResolveRoboticsURICpp
         LANGUAGES CXX C
-        VERSION 0.0.3)
+        VERSION 0.1.0)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ target_link_libraries(<...> PRIVATE ResolveRoboticsURICpp::ResolveRoboticsURICpp
 include(FetchContent)
 FetchContent_Declare(
   ResolveRoboticsURICpp
-  GIT_REPOSITORY https://github.com/ami-iit/resolve-robotics-uri-cpp
+  GIT_REPOSITORY https://github.com/gbionics/resolve-robotics-uri-cpp
   GIT_TAG        v0.1.0 # Or change this to use another release or tag
 )
 FetchContent_MakeAvailable(ResolveRoboticsURICpp)
@@ -41,7 +41,7 @@ target_link_libraries(<...> PRIVATE ResolveRoboticsURICpp::ResolveRoboticsURICpp
 ### Install from source and find the CMake package in your project
 
 ~~~bash
-git clone https://github.com/ami-iit/resolve-robotics-uri-cpp
+git clone https://github.com/gbionics/resolve-robotics-uri-cpp
 cd resolve-robotics-uri-cpp
 cmake -S. -Bbuild -DCMAKE_INSTALL_PREFIX=./build/install -DCMAKE_BUILD_TYPE=Release .
 cmake --build build
@@ -50,6 +50,7 @@ export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:`pwd`/build/install
 ~~~
 
 Then in your project:
+
 ~~~cmake
 find_package(ResolveRoboticsURICpp REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ Pure C++ library (that only depends on C++ standard library) to resolve a packag
 
 The `resolve-robotics-uri-cpp` is composed by a single self-contained header, `ResolveRoboticsURICpp.h`. You can directly use the header in your project, or install the library using one method described in the following.
 
+### Installation via conda-forge
+
+The `resolve-robotics-uri-cpp` is available in the [`libresolve-robotics-uri-cpp`](https://prefix.dev/channels/conda-forge/packages/libresolve-robotics-uri-cpp) conda-forge package, so you can install it with your favority conda tool, for example pixi:
+
+~~~
+pixi add libresolve-robotics-uri-cpp
+~~~
+
+and then use it in your CMake project with:
+
+~~~cmake
+find_package(ResolveRoboticsURICpp REQUIRED)
+
+# Use the provided target 
+target_link_libraries(<...> PRIVATE ResolveRoboticsURICpp::ResolveRoboticsURICpp)
+~~~
+
 ### Installation via FetchContent
 
 ~~~cmake
@@ -13,7 +30,7 @@ include(FetchContent)
 FetchContent_Declare(
   ResolveRoboticsURICpp
   GIT_REPOSITORY https://github.com/ami-iit/resolve-robotics-uri-cpp
-  GIT_TAG        v0.0.1 # Or change this to use another release or tag
+  GIT_TAG        v0.1.0 # Or change this to use another release or tag
 )
 FetchContent_MakeAvailable(ResolveRoboticsURICpp)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pure C++ library (that only depends on C++ standard library) to resolve a packag
 
 ## Installation
 
-The `resolve-robotics-uri-cpp` is composed by a single sellf-contained header, `ResolveRoboticsURICpp.h`. You can directly use the header in your project, or install the library using one method described in the following.
+The `resolve-robotics-uri-cpp` is composed by a single self-contained header, `ResolveRoboticsURICpp.h`. You can directly use the header in your project, or install the library using one method described in the following.
 
 ### Installation via FetchContent
 
@@ -62,6 +62,18 @@ If you want to get the location of the `panda`  model installed by [`moveit_reso
 std::optional<std::string> absolute_path = ResolveRoboticsURICpp::resolveRoboticsURI("package://moveit_resources_panda_description/urdf/panda.urdf")
 ~~~
 
+To customize search behavior (for example disable active-prefix search or exclude specific env vars):
+
+~~~cxx
+ResolveRoboticsURICpp::ResolveRoboticsURIOptions options;
+options.excludeActivePrefix = true;
+options.excludeEnvVars.insert("GAZEBO_MODEL_PATH");
+options.packageDirs.push_back("/custom/share/root");
+
+std::optional<std::string> absolute_path =
+  ResolveRoboticsURICpp::resolveRoboticsURI("package://example_pkg/model.urdf", options);
+~~~
+
 ## Command Line usage
 
 `resolve-robotics-uri-cpp` also install a command line tool called `resolve-robotics-uri-cpp` for use in scripts, that can be used as:
@@ -70,9 +82,29 @@ std::optional<std::string> absolute_path = ResolveRoboticsURICpp::resolveRobotic
 resolve-robotics-uri-cpp package://iCub/robots/iCubGazeboV2_7/model.urdf
 ~~~
 
+You can also control search options from the command line:
+
+~~~
+resolve-robotics-uri-cpp --exclude-active-prefix --exclude-env-var GAZEBO_MODEL_PATH package://iCub/robots/iCubGazeboV2_7/model.urdf
+~~~
+
 For example,  on bash this can be used to easily convert the a urdf specified via `package://` to an sdf (assuming you have Gazebo installed), using the [backtick operator](https://www.redhat.com/sysadmin/backtick-operator-vs-parens):
 ~~~
 gz sdf -p `resolve-robotics-uri-cpp package://iCub/robots/iCubGazeboV2_7/model.urdf`
+~~~
+
+## Details On How Files Are Searched
+
+You can find detailed file search rules in [rru_spec.md](rru_spec.md).
+
+## Example Pure CMake/C++ Package Installing `cube.urdf`
+
+An example pure CMake/C++ project that installs a resource in a ROS-compatible layout is available in [examples/example_cmake_package](examples/example_cmake_package).
+
+After installation in an active conda or virtual environment prefix, the file can be resolved with:
+
+~~~
+resolve-robotics-uri-cpp package://example_cmake_package/cube.urdf
 ~~~
 
 ## Python version

--- a/ResolveRoboticsURICpp.h
+++ b/ResolveRoboticsURICpp.h
@@ -4,16 +4,31 @@
 #ifndef RESOLVE_ROBOTICS_URI_CPP_H
 #define RESOLVE_ROBOTICS_URI_CPP_H
 
+#include <cstdio>
+#include <cstdlib>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 namespace ResolveRoboticsURICpp
 {
 
-std::string cleanPathSeparator(const std::string& filename, const bool isWindows)
+struct ResolveRoboticsURIOptions
+{
+    // Disable searching inside the active environment prefix (<prefix>/share).
+    bool excludeActivePrefix = false;
+
+    // Exclude specific env vars from default search path extraction.
+    std::unordered_set<std::string> excludeEnvVars;
+
+    // Additional directories to search as-is.
+    std::vector<std::string> packageDirs;
+};
+
+inline std::string cleanPathSeparator(const std::string& filename, const bool isWindows)
 {
     std::string output = filename;
     char pathSeparator = isWindows ? '\\' : '/';
@@ -28,7 +43,7 @@ std::string cleanPathSeparator(const std::string& filename, const bool isWindows
     return output;
 }
 
-bool isFileExisting(const std::string& filename)
+inline bool isFileExisting(const std::string& filename)
 {
     if (FILE* file = fopen(filename.c_str(), "r"))
     {
@@ -40,31 +55,105 @@ bool isFileExisting(const std::string& filename)
     }
 }
 
-bool getFilePath(const std::string& filename,
-                 const std::string& prefixToRemove,
-                 const std::unordered_set<std::string>& paths,
-                 const bool isWindows,
-                 std::string& outputFileName)
+inline std::string joinPaths(const std::string& base,
+                             const std::string& suffix,
+                             const bool isWindows)
 {
-    if (filename.substr(0, prefixToRemove.size()) == prefixToRemove)
+    if (base.empty())
     {
-        std::string filename_noprefix = filename;
-        filename_noprefix.erase(0, prefixToRemove.size());
-        for (const std::string& path : paths)
+        return suffix;
+    }
+
+    if (suffix.empty())
+    {
+        return base;
+    }
+
+    const char pathSeparator = isWindows ? '\\' : '/';
+    const bool baseHasSeparator = base.back() == '/' || base.back() == '\\';
+    const bool suffixHasSeparator = suffix.front() == '/' || suffix.front() == '\\';
+
+    if (baseHasSeparator && suffixHasSeparator)
+    {
+        return base + suffix.substr(1);
+    }
+
+    if (!baseHasSeparator && !suffixHasSeparator)
+    {
+        return base + pathSeparator + suffix;
+    }
+
+    return base + suffix;
+}
+
+inline bool getFilePath(const std::string& filename,
+                        const std::string& prefixToRemove,
+                        const std::unordered_set<std::string>& paths,
+                        const bool isWindows,
+                        std::string& outputFileName)
+{
+    if (filename.substr(0, prefixToRemove.size()) != prefixToRemove)
+    {
+        return false;
+    }
+
+    std::string filenameNoPrefix = filename;
+    filenameNoPrefix.erase(0, prefixToRemove.size());
+
+    for (const std::string& path : paths)
+    {
+        const std::string testPath =
+            cleanPathSeparator(joinPaths(path, filenameNoPrefix, isWindows), isWindows);
+        if (isFileExisting(testPath))
         {
-            const std::string testPath = cleanPathSeparator(path + filename_noprefix, isWindows);
-            if (isFileExisting(testPath))
-            {
-                outputFileName = testPath;
-                return true;
-            }
+            outputFileName = testPath;
+            return true;
         }
     }
+
     return false;
 }
 
-std::optional<std::string>
-resolveRoboticsURI(const std::string& uriFilename, std::string& errorMessage)
+inline std::unordered_map<std::string, bool> getSupportedEnvVars()
+{
+    // true means the variable contains prefixes and we append /share,
+    // false means we search the provided directories as-is.
+    return {{"ROS_PACKAGE_PATH", false},
+            {"GAZEBO_MODEL_PATH", false},
+            {"SDF_PATH", false},
+            {"IGN_GAZEBO_RESOURCE_PATH", false},
+            {"GZ_SIM_RESOURCE_PATH", false},
+            {"RRU_ADDITIONAL_PATHS", false},
+            {"AMENT_PREFIX_PATH", true}};
+}
+
+inline bool isEnvVarExcluded(const std::string& envVarName,
+                             const ResolveRoboticsURIOptions& options)
+{
+    return options.excludeEnvVars.find(envVarName) != options.excludeEnvVars.end();
+}
+
+inline std::optional<std::string> getActivePrefixPath()
+{
+    const char* condaPrefix = std::getenv("CONDA_PREFIX");
+    if (condaPrefix && std::string(condaPrefix).size() > 0)
+    {
+        return std::string(condaPrefix);
+    }
+
+    const char* virtualEnv = std::getenv("VIRTUAL_ENV");
+    if (virtualEnv && std::string(virtualEnv).size() > 0)
+    {
+        return std::string(virtualEnv);
+    }
+
+    return {};
+}
+
+inline std::optional<std::string>
+resolveRoboticsURI(const std::string& uriFilename,
+                   const ResolveRoboticsURIOptions& options,
+                   std::string& errorMessage)
 {
     bool isWindows = false;
 #ifdef _WIN32
@@ -90,11 +179,11 @@ resolveRoboticsURI(const std::string& uriFilename, std::string& errorMessage)
         return uriFilename;
     }
 
-    std::string packageUriPrefix = "package:/";
-    std::string modelUriPrefix = "model:/";
+    const std::string packageUriPrefix = "package:/";
+    const std::string modelUriPrefix = "model:/";
 
     if (uriFilename.substr(0, packageUriPrefix.size()) != packageUriPrefix
-        && modelUriPrefix.substr(0, modelUriPrefix.size()) != modelUriPrefix)
+        && uriFilename.substr(0, modelUriPrefix.size()) != modelUriPrefix)
     {
         // The uri does not start with file:/ (earlier check, is not a file path
         // or start with model:/ or package:/, we can't resolve it
@@ -110,7 +199,7 @@ resolveRoboticsURI(const std::string& uriFilename, std::string& errorMessage)
         uriPrefix = packageUriPrefix;
     }
 
-    if (modelUriPrefix.substr(0, modelUriPrefix.size()) == packageUriPrefix)
+    if (uriFilename.substr(0, modelUriPrefix.size()) == modelUriPrefix)
     {
         uriPrefix = modelUriPrefix;
     }
@@ -120,46 +209,60 @@ resolveRoboticsURI(const std::string& uriFilename, std::string& errorMessage)
     // At this point, let's process the actual case of package:/ or model:/ URIs
     std::unordered_set<std::string> pathList;
 
-    // List of variables that contain <prefix>/share paths
-    std::vector<std::string> envListShare = {"ROS_PACKAGE_PATH",
-                                             "GAZEBO_MODEL_PATH",
-                                             "SDF_PATH",
-                                             "IGN_GAZEBO_RESOURCE_PATH",
-                                             "GZ_SIM_RESOURCE_PATH"};
-
-    // List of variables that contains <prefix> paths (to which /share needs
-    // to be added)
-    std::vector<std::string> envListPrefix = {"AMENT_PREFIX_PATH"};
-
     // Extract list of directories where to search for the file
-    for (size_t i = 0; i < envListShare.size(); ++i)
+    const auto supportedEnvVars = getSupportedEnvVars();
+    for (const auto& envSpec : supportedEnvVars)
     {
-        const char* env_var_value = std::getenv(envListShare[i].c_str());
-        if (env_var_value)
+        const std::string& envVarName = envSpec.first;
+        const bool isPrefixEnvVar = envSpec.second;
+
+        if (isEnvVarExcluded(envVarName, options))
         {
-            std::stringstream env_var_string(env_var_value);
-            std::string individualPath;
-            while (std::getline(env_var_string, individualPath, isWindows ? ';' : ':'))
+            continue;
+        }
+
+        const char* envVarValue = std::getenv(envVarName.c_str());
+        if (!envVarValue)
+        {
+            continue;
+        }
+
+        std::stringstream envVarString(envVarValue);
+        std::string individualPath;
+        while (std::getline(envVarString, individualPath, isWindows ? ';' : ':'))
+        {
+            if (individualPath.empty())
+            {
+                continue;
+            }
+
+            if (isPrefixEnvVar)
+            {
+                pathList.insert(individualPath + "/share");
+            } else
             {
                 pathList.insert(individualPath);
             }
         }
     }
 
-    for (size_t i = 0; i < envListPrefix.size(); ++i)
+    if (!options.excludeActivePrefix)
     {
-        const char* env_var_value = std::getenv(envListPrefix[i].c_str());
-
-        if (env_var_value)
+        const std::optional<std::string> activePrefix = getActivePrefixPath();
+        if (activePrefix.has_value())
         {
-            std::stringstream env_var_string(env_var_value);
+            pathList.insert(activePrefix.value() + "/share");
+#ifdef _WIN32
+            pathList.insert(activePrefix.value() + "/Library/share");
+#endif
+        }
+    }
 
-            std::string individualPath;
-
-            while (std::getline(env_var_string, individualPath, isWindows ? ';' : ':'))
-            {
-                pathList.insert(individualPath + "/share");
-            }
+    for (const std::string& packageDir : options.packageDirs)
+    {
+        if (!packageDir.empty())
+        {
+            pathList.insert(packageDir);
         }
     }
 
@@ -176,10 +279,25 @@ resolveRoboticsURI(const std::string& uriFilename, std::string& errorMessage)
     }
 }
 
-std::optional<std::string> resolveRoboticsURI(const std::string& uriFilename)
+inline std::optional<std::string>
+resolveRoboticsURI(const std::string& uriFilename, std::string& errorMessage)
+{
+    ResolveRoboticsURIOptions defaultOptions;
+    return resolveRoboticsURI(uriFilename, defaultOptions, errorMessage);
+}
+
+inline std::optional<std::string>
+resolveRoboticsURI(const std::string& uriFilename, const ResolveRoboticsURIOptions& options)
 {
     std::string dummyErrorMessage;
-    return resolveRoboticsURI(uriFilename, dummyErrorMessage);
+    return resolveRoboticsURI(uriFilename, options, dummyErrorMessage);
+}
+
+inline std::optional<std::string> resolveRoboticsURI(const std::string& uriFilename)
+{
+    std::string dummyErrorMessage;
+    ResolveRoboticsURIOptions defaultOptions;
+    return resolveRoboticsURI(uriFilename, defaultOptions, dummyErrorMessage);
 }
 
 } // namespace ResolveRoboticsURICpp

--- a/examples/example_cmake_package/CMakeLists.txt
+++ b/examples/example_cmake_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(example_cmake_package LANGUAGES CXX)
+
+install(FILES package.xml DESTINATION share/${PROJECT_NAME})
+install(FILES share/${PROJECT_NAME}/cube.urdf DESTINATION share/${PROJECT_NAME})
+
+# ROS 2 package discovery marker.
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}" "")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}"
+        DESTINATION share/ament_index/resource_index/packages)

--- a/examples/example_cmake_package/README.md
+++ b/examples/example_cmake_package/README.md
@@ -1,0 +1,27 @@
+# example_cmake_package
+
+This example shows how a pure CMake/C++ project can install a ROS-style resource into `share/` so `resolve-robotics-uri-cpp` can find it with `package://example_cmake_package/cube.urdf`.
+
+The install step places:
+
+- `share/example_cmake_package/cube.urdf`
+- `share/example_cmake_package/package.xml`
+- `share/ament_index/resource_index/packages/example_cmake_package`
+
+That layout is compatible with ROS resource discovery and with `resolve-robotics-uri-cpp` default search rules.
+
+## Build and Install
+
+```bash
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+cmake --build build
+cmake --install build
+```
+
+If you are not using conda, replace `$CONDA_PREFIX` with your chosen prefix, and set `AMENT_PREFIX_PATH` to your install prefix before resolving.
+
+## Try It
+
+```bash
+resolve-robotics-uri-cpp package://example_cmake_package/cube.urdf
+```

--- a/examples/example_cmake_package/package.xml
+++ b/examples/example_cmake_package/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>example_cmake_package</name>
+  <version>0.1.0</version>
+  <description>Example of a pure CMake/C++ package that installs data files in a way that can be found by resolve-robotics-uri-cpp and regular ROS tooling.</description>
+  <maintainer email="silvio.traversaro@gbionics.ai">Silvio Traversaro</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/examples/example_cmake_package/share/example_cmake_package/cube.urdf
+++ b/examples/example_cmake_package/share/example_cmake_package/cube.urdf
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<robot name="example_cube">
+  <link name="base_link">
+    <inertial>
+      <mass value="1.0"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertia ixx="0.0016666667" ixy="0" ixz="0" iyy="0.0016666667" iyz="0" izz="0.0016666667"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+      <material name="blue">
+        <color rgba="0.2 0.4 0.9 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>

--- a/resolve-robotics-uri-cpp.cpp
+++ b/resolve-robotics-uri-cpp.cpp
@@ -6,18 +6,74 @@
 #include <cstdlib>
 #include <iostream>
 #include <optional>
+#include <unordered_set>
 
 int main(int argc, char* argv[])
 {
     if (argc < 2)
     {
         std::cerr << "resolve-robotics-uri-cpp: Wrong number of parameters. Usage " << argv[0]
-                  << " package://uri/of/the/model/to/resolve " << std::endl;
+                  << " [--exclude-active-prefix] [--exclude-env-var NAME]"
+                     " [--package-dir PATH] URI"
+                  << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    ResolveRoboticsURICpp::ResolveRoboticsURIOptions options;
+    std::string uri;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        const std::string arg = argv[i];
+        if (arg == "--exclude-active-prefix")
+        {
+            options.excludeActivePrefix = true;
+            continue;
+        }
+
+        if (arg == "--exclude-env-var")
+        {
+            if (i + 1 >= argc)
+            {
+                std::cerr << "resolve-robotics-uri-cpp: Missing argument for --exclude-env-var"
+                          << std::endl;
+                return EXIT_FAILURE;
+            }
+
+            options.excludeEnvVars.insert(argv[++i]);
+            continue;
+        }
+
+        if (arg == "--package-dir")
+        {
+            if (i + 1 >= argc)
+            {
+                std::cerr << "resolve-robotics-uri-cpp: Missing argument for --package-dir"
+                          << std::endl;
+                return EXIT_FAILURE;
+            }
+
+            options.packageDirs.push_back(argv[++i]);
+            continue;
+        }
+
+        if (!uri.empty())
+        {
+            std::cerr << "resolve-robotics-uri-cpp: Multiple URI arguments passed." << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        uri = arg;
+    }
+
+    if (uri.empty())
+    {
+        std::cerr << "resolve-robotics-uri-cpp: Missing URI argument." << std::endl;
         return EXIT_FAILURE;
     }
 
     std::string errorMessage;
-    auto absolute_file_name = ResolveRoboticsURICpp::resolveRoboticsURI(argv[1], errorMessage);
+    auto absolute_file_name = ResolveRoboticsURICpp::resolveRoboticsURI(uri, options, errorMessage);
 
     if (absolute_file_name.has_value())
     {

--- a/rru_spec.md
+++ b/rru_spec.md
@@ -1,0 +1,78 @@
+# File Search Rules
+
+`resolve-robotics-uri-cpp` resolves URIs by following the rules below.
+
+## Supported URI Schemes
+
+The resolver accepts these schemes:
+
+- `file://`
+- `package://`
+- `model://`
+
+If a path is passed without a scheme, it is treated as a local file path and checked directly.
+
+## `file://` Resolution
+
+For `file://` URIs, the path is converted to a local filesystem path and checked directly.
+The file must exist and be readable.
+
+## `package://` and `model://` Resolution
+
+For scoped URIs, the resolver strips the scheme and searches for the remaining relative path under a set of candidate directories.
+
+The search order is:
+
+1. Search paths derived from supported environment variables.
+2. Search paths derived from the active C++ environment prefix (`CONDA_PREFIX`, or fallback `VIRTUAL_ENV`), unless excluded.
+3. Any directories passed explicitly through `ResolveRoboticsURIOptions::packageDirs`.
+
+If multiple matching files are found, the first one encountered in the internal path set iteration is returned.
+
+## Environment Variables Used For Search
+
+The resolver reads these environment variables by default:
+
+- `AMENT_PREFIX_PATH`
+- `GAZEBO_MODEL_PATH`
+- `GZ_SIM_RESOURCE_PATH`
+- `IGN_GAZEBO_RESOURCE_PATH`
+- `ROS_PACKAGE_PATH`
+- `SDF_PATH`
+- `RRU_ADDITIONAL_PATHS`
+
+Each variable may contain multiple paths separated by the OS path separator (`:` on POSIX, `;` on Windows).
+
+Special handling applies to `AMENT_PREFIX_PATH`: each entry is interpreted as a prefix and `share` is appended before searching.
+
+All other variables are searched as-is.
+
+## Active Prefix Search Paths
+
+By default, the resolver considers the active environment prefix:
+
+- `CONDA_PREFIX`
+- if `CONDA_PREFIX` is not defined: `VIRTUAL_ENV`
+
+For that prefix, it searches:
+
+- `<prefix>/share`
+- On Windows only: `<prefix>/Library/share`
+
+This makes it possible to resolve ROS-style resources installed by pure CMake/C++ projects or other tools that place files under `share/<package_name>/` in active environments.
+
+You can disable active-prefix-based search by setting `ResolveRoboticsURIOptions::excludeActivePrefix = true`.
+
+## Excluding Environment Variables
+
+You can exclude specific environment variables from the default path extraction by adding their names to `ResolveRoboticsURIOptions::excludeEnvVars`.
+
+## Explicit Additional Directories
+
+`ResolveRoboticsURIOptions::packageDirs` adds extra directories to the search set.
+
+These directories are searched in addition to default environment-based and active-prefix-based paths.
+
+## Failure Behavior
+
+If no matching file is found, the resolver returns an empty `std::optional` and fills the error message when provided.

--- a/test/ResolveRoboticsURICppUnitTests.cpp
+++ b/test/ResolveRoboticsURICppUnitTests.cpp
@@ -5,9 +5,194 @@
 
 #include <ResolveRoboticsURICpp.h>
 
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+class ScopedEnvVar
+{
+public:
+    explicit ScopedEnvVar(const std::string& name)
+        : m_name(name)
+    {
+        const char* existing = std::getenv(m_name.c_str());
+        if (existing)
+        {
+            m_hadOriginalValue = true;
+            m_originalValue = existing;
+        }
+    }
+
+    ~ScopedEnvVar()
+    {
+        if (m_hadOriginalValue)
+        {
+            set(m_originalValue);
+        } else
+        {
+            unset();
+        }
+    }
+
+    void set(const std::string& value)
+    {
+#ifdef _WIN32
+        _putenv_s(m_name.c_str(), value.c_str());
+#else
+        setenv(m_name.c_str(), value.c_str(), 1);
+#endif
+    }
+
+    void unset()
+    {
+#ifdef _WIN32
+        _putenv_s(m_name.c_str(), "");
+#else
+        unsetenv(m_name.c_str());
+#endif
+    }
+
+private:
+    std::string m_name;
+    bool m_hadOriginalValue = false;
+    std::string m_originalValue;
+};
+
+std::filesystem::path writeFile(const std::filesystem::path& filePath,
+                                const std::string& content = "test")
+{
+    std::filesystem::create_directories(filePath.parent_path());
+    std::ofstream output(filePath);
+    output << content;
+    return filePath;
+}
+
+std::vector<std::string> supportedEnvVars()
+{
+    return {"ROS_PACKAGE_PATH",
+            "GAZEBO_MODEL_PATH",
+            "SDF_PATH",
+            "IGN_GAZEBO_RESOURCE_PATH",
+            "GZ_SIM_RESOURCE_PATH",
+            "RRU_ADDITIONAL_PATHS",
+            "AMENT_PREFIX_PATH",
+            "CONDA_PREFIX",
+            "VIRTUAL_ENV"};
+}
+
+} // namespace
+
 TEST_CASE("FileDoesNotExist")
 {
     CHECK_FALSE(ResolveRoboticsURICpp::resolveRoboticsURI("package://this/package/and/file/does/"
                                                           "not.exist")
                     .has_value());
+}
+
+TEST_CASE("ResolveFromCondaPrefixAndOptOut")
+{
+    std::vector<std::unique_ptr<ScopedEnvVar>> scopedEnvVars;
+    scopedEnvVars.reserve(supportedEnvVars().size());
+    for (const auto& envVar : supportedEnvVars())
+    {
+        scopedEnvVars.emplace_back(new ScopedEnvVar(envVar));
+        scopedEnvVars.back()->unset();
+    }
+
+    ScopedEnvVar condaPrefix("CONDA_PREFIX");
+    condaPrefix.unset();
+
+    const std::filesystem::path prefixPath =
+        std::filesystem::temp_directory_path() / "rru_cpp_conda_prefix_test";
+    const std::filesystem::path cubeUrdf =
+        writeFile(prefixPath / "share" / "example_cpp_package" / "cube.urdf", "<robot/>");
+
+    condaPrefix.set(prefixPath.string());
+
+    const std::string uri = "package://example_cpp_package/cube.urdf";
+    auto resolved = ResolveRoboticsURICpp::resolveRoboticsURI(uri);
+    REQUIRE(resolved.has_value());
+    CHECK(resolved.value() == cubeUrdf.string());
+
+    ResolveRoboticsURICpp::ResolveRoboticsURIOptions options;
+    options.excludeActivePrefix = true;
+    CHECK_FALSE(ResolveRoboticsURICpp::resolveRoboticsURI(uri, options).has_value());
+
+    std::filesystem::remove_all(prefixPath);
+}
+
+TEST_CASE("ResolveFromVirtualEnvPrefixFallback")
+{
+    std::vector<std::unique_ptr<ScopedEnvVar>> scopedEnvVars;
+    scopedEnvVars.reserve(supportedEnvVars().size());
+    for (const auto& envVar : supportedEnvVars())
+    {
+        scopedEnvVars.emplace_back(new ScopedEnvVar(envVar));
+        scopedEnvVars.back()->unset();
+    }
+
+    ScopedEnvVar virtualEnv("VIRTUAL_ENV");
+    virtualEnv.unset();
+
+    const std::filesystem::path prefixPath =
+        std::filesystem::temp_directory_path() / "rru_cpp_virtualenv_prefix_test";
+    const std::filesystem::path cubeUrdf =
+        writeFile(prefixPath / "share" / "example_cpp_package" / "cube.urdf", "<robot/>");
+
+    virtualEnv.set(prefixPath.string());
+
+    auto resolved =
+        ResolveRoboticsURICpp::resolveRoboticsURI("package://example_cpp_package/cube.urdf");
+    REQUIRE(resolved.has_value());
+    CHECK(resolved.value() == cubeUrdf.string());
+
+    std::filesystem::remove_all(prefixPath);
+}
+
+TEST_CASE("ExcludeEnvVar")
+{
+    ScopedEnvVar gazeboModelPath("GAZEBO_MODEL_PATH");
+    gazeboModelPath.unset();
+
+    const std::filesystem::path modelDir =
+        std::filesystem::temp_directory_path() / "rru_cpp_gazebo_model_path_test";
+    const std::filesystem::path modelFile = writeFile(modelDir / "example_model");
+
+    gazeboModelPath.set(modelDir.string());
+
+    auto resolved = ResolveRoboticsURICpp::resolveRoboticsURI("model://example_model");
+    REQUIRE(resolved.has_value());
+    CHECK(resolved.value() == modelFile.string());
+
+    ResolveRoboticsURICpp::ResolveRoboticsURIOptions options;
+    options.excludeEnvVars.insert("GAZEBO_MODEL_PATH");
+    CHECK_FALSE(ResolveRoboticsURICpp::resolveRoboticsURI("model://example_model", options)
+                    .has_value());
+
+    std::filesystem::remove_all(modelDir);
+}
+
+TEST_CASE("AdditionalPackageDirs")
+{
+    const std::filesystem::path additionalDir =
+        std::filesystem::temp_directory_path() / "rru_cpp_package_dirs_test";
+    const std::filesystem::path cubeUrdf =
+        writeFile(additionalDir / "example_cpp_package" / "cube.urdf", "<robot/>");
+
+    ResolveRoboticsURICpp::ResolveRoboticsURIOptions options;
+    options.excludeActivePrefix = true;
+    options.packageDirs.push_back(additionalDir.string());
+
+    auto resolved =
+        ResolveRoboticsURICpp::resolveRoboticsURI("package://example_cpp_package/cube.urdf", options);
+    REQUIRE(resolved.has_value());
+    CHECK(resolved.value() == cubeUrdf.string());
+
+    std::filesystem::remove_all(additionalDir);
 }


### PR DESCRIPTION
## Overview

When working with virtual environments (for C++ projects, tipically in conda-style environments, but in case C++ code is used in Python bindings also in Python virtualenv) it is a bit pointless to have to set environment variables like `AMENT_PREFIX_PATH` or `GZ_SIM_RESOURCE_PATH`, when the packages that are installed are installed in the root of the virtual environment.

To reduce the amount of time friction of when it is necessary to set `AMENT_PREFIX_PATH` or `GZ_SIM_RESOURCE_PATH`, this PR modifies `resolve-robotics-uri-cpp` to also search automatically:
* The `share` subfolder of the directory specified in `CONDA_PREFIX`, and if that is not defined, the `share` subfolder of the folder in `VIRTUAL_ENV`
* Only on Windows, the `share/Library` subfolder of virtual environment prefix, as defined in the previous point

This for example permits to install models (or in general any file accessible via `package://` URIs) as part of pure C++ packages in a virtual environment, and to find such models without the need to set any environment variable.

## Other modifications of the PR

Some other modifications are included in the PR, as they were useful for this change. The only modifications that are really important are the modification (that are relatively limited) to the `ResolveRoboticsURICpp.h` file.

### Specification of resolve-robotics-uri search logic

As the search logic was already complex, and it became more complex with this PR, the `rru_spec.md` file has been added to describe in detail how files are searched by `resolve-robotics-uri-cpp`.

### `examples/example_cmake_package`

An example of a cmake package that installs files via and that can be found via the new functionality introduced in this PR (if installed in an active environment) and that can be found also by regular ROS 2 tooling.

### Options to opt-out for some search logic

As some users may not want to search for files in python install prefix, so option `exclude_python_prefix` has been added, that can be set to false if you do not want to search for Python install prefix.
 