### PR TITLE
Add support for solving directories from uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # resolve-robotics-uri-cpp
 
-Pure C++ library (that only depends on C++ standard library) to resolve a package:// (ROS-style) or model:// (Gazebo-style) URI to an absolute filename.
+Pure C++ library (that only depends on C++ standard library) to resolve a package:// (ROS-style) or model:// (Gazebo-style) URI to an absolute filesystem path (file or directory).
 
 ## Installation
 

--- a/ResolveRoboticsURICpp.h
+++ b/ResolveRoboticsURICpp.h
@@ -50,6 +50,40 @@ inline bool isPathExisting(const std::string& filename)
     return std::filesystem::exists(filename, ec);
 }
 
+inline std::string fileUriToLocalPath(const std::string& uriFilename, const bool isWindows)
+{
+    const std::string fileScheme = "file:";
+    if (uriFilename.substr(0, fileScheme.size()) != fileScheme)
+    {
+        return uriFilename;
+    }
+
+    std::string localPath = uriFilename.substr(fileScheme.size());
+
+    if (isWindows)
+    {
+        while (!localPath.empty() && (localPath.front() == '/' || localPath.front() == '\\'))
+        {
+            localPath.erase(0, 1);
+        }
+
+        return cleanPathSeparator(localPath, isWindows);
+    }
+
+    std::size_t leadingSlashCount = 0;
+    while (leadingSlashCount < localPath.size() && localPath[leadingSlashCount] == '/')
+    {
+        ++leadingSlashCount;
+    }
+
+    if (leadingSlashCount > 1)
+    {
+        localPath.erase(0, leadingSlashCount - 1);
+    }
+
+    return localPath;
+}
+
 inline std::string joinPaths(const std::string& base,
                              const std::string& suffix,
                              const bool isWindows)
@@ -155,12 +189,11 @@ resolveRoboticsURI(const std::string& uriFilename,
     isWindows = true;
 #endif
 
-    // If file starts with file:/, remove file:/ and return if it exists
-    std::string fileUriPrefix = "file:/";
-    if (uriFilename.substr(0, fileUriPrefix.size()) == fileUriPrefix)
+    // If path starts with file:, convert to local path and return if it exists.
+    const std::string fileScheme = "file:";
+    if (uriFilename.substr(0, fileScheme.size()) == fileScheme)
     {
-        std::string uriFilename_noprefix = uriFilename;
-        uriFilename_noprefix.erase(0, fileUriPrefix.size());
+        const std::string uriFilename_noprefix = fileUriToLocalPath(uriFilename, isWindows);
 
         if (isPathExisting(uriFilename_noprefix))
         {

--- a/ResolveRoboticsURICpp.h
+++ b/ResolveRoboticsURICpp.h
@@ -6,6 +6,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <filesystem>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -43,16 +44,10 @@ inline std::string cleanPathSeparator(const std::string& filename, const bool is
     return output;
 }
 
-inline bool isFileExisting(const std::string& filename)
+inline bool isPathExisting(const std::string& filename)
 {
-    if (FILE* file = fopen(filename.c_str(), "r"))
-    {
-        fclose(file);
-        return true;
-    } else
-    {
-        return false;
-    }
+    std::error_code ec;
+    return std::filesystem::exists(filename, ec);
 }
 
 inline std::string joinPaths(const std::string& base,
@@ -104,7 +99,7 @@ inline bool getFilePath(const std::string& filename,
     {
         const std::string testPath =
             cleanPathSeparator(joinPaths(path, filenameNoPrefix, isWindows), isWindows);
-        if (isFileExisting(testPath))
+        if (isPathExisting(testPath))
         {
             outputFileName = testPath;
             return true;
@@ -167,14 +162,14 @@ resolveRoboticsURI(const std::string& uriFilename,
         std::string uriFilename_noprefix = uriFilename;
         uriFilename_noprefix.erase(0, fileUriPrefix.size());
 
-        if (isFileExisting(uriFilename_noprefix))
+        if (isPathExisting(uriFilename_noprefix))
         {
             return uriFilename_noprefix;
         }
     }
 
     // If the file exists with removing any prefix, just return it
-    if (isFileExisting(uriFilename))
+    if (isPathExisting(uriFilename))
     {
         return uriFilename;
     }

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,7 +29,7 @@ configure = { cmd = [
 ]}
 
 build = { cmd = "cmake --build .build --config Release", depends-on = ["configure"] }
-test = { cmd = "ctest --test-dir .build --build-config Release", depends-on = ["build"] }
+test = { cmd = "ctest --test-dir .build --build-config Release --output-on-failure", depends-on = ["build"] }
 install = { cmd = ["cmake", "--install", ".build", "--config", "Release"], depends-on = ["build"] }
 uninstall = { cmd = ["cmake", "--build", ".build", "--target", "uninstall"]}
 format = { cmd = "clang-format -i *.cpp *.h ./test/*.cpp" }

--- a/rru_spec.md
+++ b/rru_spec.md
@@ -15,7 +15,7 @@ If a path is passed without a scheme, it is treated as a local file path and che
 ## `file://` Resolution
 
 For `file://` URIs, the path is converted to a local filesystem path and checked directly.
-The file must exist and be readable.
+The path can point to either a file or a directory, and it must exist.
 
 ## `package://` and `model://` Resolution
 
@@ -75,4 +75,4 @@ These directories are searched in addition to default environment-based and acti
 
 ## Failure Behavior
 
-If no matching file is found, the resolver returns an empty `std::optional` and fills the error message when provided.
+If no matching path is found, the resolver returns an empty `std::optional` and fills the error message when provided.

--- a/test/ResolveRoboticsURICppUnitTests.cpp
+++ b/test/ResolveRoboticsURICppUnitTests.cpp
@@ -79,6 +79,17 @@ std::filesystem::path writeDirectory(const std::filesystem::path& directoryPath)
     return directoryPath;
 }
 
+std::string fileUriFromPath(const std::filesystem::path& path)
+{
+    const std::string genericPath = path.generic_string();
+    if (!genericPath.empty() && genericPath.front() == '/')
+    {
+        return "file://" + genericPath;
+    }
+
+    return "file:///" + genericPath;
+}
+
 std::vector<std::string> supportedEnvVars()
 {
     return {"ROS_PACKAGE_PATH",
@@ -222,7 +233,7 @@ TEST_CASE("ResolveExistingDirectoryFileUri")
         writeDirectory(std::filesystem::temp_directory_path() / "rru_cpp_file_uri_dir_test"
                        / "nested_dir");
 
-    auto resolved = ResolveRoboticsURICpp::resolveRoboticsURI("file://" + directoryPath.string());
+    auto resolved = ResolveRoboticsURICpp::resolveRoboticsURI(fileUriFromPath(directoryPath));
     REQUIRE(resolved.has_value());
     CHECK(std::filesystem::equivalent(std::filesystem::path(resolved.value()), directoryPath));
 

--- a/test/ResolveRoboticsURICppUnitTests.cpp
+++ b/test/ResolveRoboticsURICppUnitTests.cpp
@@ -73,6 +73,12 @@ std::filesystem::path writeFile(const std::filesystem::path& filePath,
     return filePath;
 }
 
+std::filesystem::path writeDirectory(const std::filesystem::path& directoryPath)
+{
+    std::filesystem::create_directories(directoryPath);
+    return directoryPath;
+}
+
 std::vector<std::string> supportedEnvVars()
 {
     return {"ROS_PACKAGE_PATH",
@@ -193,6 +199,51 @@ TEST_CASE("AdditionalPackageDirs")
         ResolveRoboticsURICpp::resolveRoboticsURI("package://example_cpp_package/cube.urdf", options);
     REQUIRE(resolved.has_value());
     CHECK(resolved.value() == cubeUrdf.string());
+
+    std::filesystem::remove_all(additionalDir);
+}
+
+TEST_CASE("ResolveExistingDirectoryPath")
+{
+    const std::filesystem::path directoryPath =
+        writeDirectory(std::filesystem::temp_directory_path() / "rru_cpp_existing_dir_test"
+                       / "nested_dir");
+
+    auto resolved = ResolveRoboticsURICpp::resolveRoboticsURI(directoryPath.string());
+    REQUIRE(resolved.has_value());
+    CHECK(resolved.value() == directoryPath.string());
+
+    std::filesystem::remove_all(std::filesystem::temp_directory_path() / "rru_cpp_existing_dir_test");
+}
+
+TEST_CASE("ResolveExistingDirectoryFileUri")
+{
+    const std::filesystem::path directoryPath =
+        writeDirectory(std::filesystem::temp_directory_path() / "rru_cpp_file_uri_dir_test"
+                       / "nested_dir");
+
+    auto resolved = ResolveRoboticsURICpp::resolveRoboticsURI("file://" + directoryPath.string());
+    REQUIRE(resolved.has_value());
+    CHECK(std::filesystem::equivalent(std::filesystem::path(resolved.value()), directoryPath));
+
+    std::filesystem::remove_all(std::filesystem::temp_directory_path() / "rru_cpp_file_uri_dir_test");
+}
+
+TEST_CASE("ResolveDirectoryFromPackageUri")
+{
+    const std::filesystem::path additionalDir =
+        std::filesystem::temp_directory_path() / "rru_cpp_package_dir_uri_test";
+    const std::filesystem::path packageDirectory =
+        writeDirectory(additionalDir / "example_cpp_package" / "meshes");
+
+    ResolveRoboticsURICpp::ResolveRoboticsURIOptions options;
+    options.excludeActivePrefix = true;
+    options.packageDirs.push_back(additionalDir.string());
+
+    auto resolved =
+        ResolveRoboticsURICpp::resolveRoboticsURI("package://example_cpp_package/meshes", options);
+    REQUIRE(resolved.has_value());
+    CHECK(resolved.value() == packageDirectory.string());
 
     std::filesystem::remove_all(additionalDir);
 }


### PR DESCRIPTION
Before this PR, searching for a folder via `package://<something>`, as the candidate path was not checked for existence, but it was checked if it was actually a file. This condition is relaxed here, to ensure that also folders can be found with `package://<something>` URIs.

Similar to https://github.com/gbionics/resolve-robotics-uri-py/pull/21 .